### PR TITLE
Fix: Stale Collection Objects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Application Framework Changelog
 
+## v7.3.7 - Countries & Locales Cache API
+
+**Patch for test suite failures caused by cross-test stale collection records.**
+
+- DBHelper: Added `clearRecordCache()` in collections as a soft reset without disposing objects.
+- Locales: Added `clearLocaleCache()` to allow resetting the locale cache after a countries collection cache clear.
+
 ## v7.3.6 - ClearableString Validation Bypass
 
 **Clearing a field via the API no longer gets blocked by its own format validators.** 

--- a/docs/agents/deferred-topics.md
+++ b/docs/agents/deferred-topics.md
@@ -61,12 +61,43 @@ knowledge.
 - Verify the full test suite passes (countries filter, mail suite, notifications suite)
   after the migration.
 
+### Generalized Test Isolation: Central Collection Cache Reset
+
+A broader improvement to consider: a generalized `tearDown()` mechanism that resets
+**all** loaded collection caches, not just Countries and Locales. The structural
+challenges that make this non-trivial:
+
+1. **Two unrelated collection hierarchies:** `DBHelper_BaseCollection` (has
+   `clearRecordCache()`) and `BaseStringPrimaryCollection` from
+   `application-utils-collections` (has `reset()` only). A single loop cannot call
+   the same method on both.
+
+2. **Three separate singleton registries:** `DBHelper::$collections` (collections
+   created via `DBHelper::createCollection()`), `AppFactory::$instances` (collections
+   created via `createClassInstance()`), and individual `getInstance()` statics
+   (`Application_Countries`, `Locales`, `Languages`). No single registry covers all
+   loaded collections.
+
+**Possible solution path:**
+
+- Introduce a `CacheResettable` interface with a single `clearCache(): void` method,
+  implemented by both `DBHelper_BaseCollection` and `BaseStringPrimaryCollection`.
+- Add a central `CollectionRegistry` where all singletons register on construction.
+- Expose a `CollectionRegistry::clearAllCaches()` method callable from
+  `ApplicationTestCase::tearDown()`.
+
+This would replace the current manual co-reset calls (Countries + Locales) and
+automatically cover any future collections without requiring test-infrastructure changes.
+
 ### Current State
 
 - `clearRecordCache()` is documented with its limitation in its docblock in
   `src/classes/DBHelper/BaseCollection.php`.
 - `Locales::clearLocaleCache()` is the only registered co-reset; it is called explicitly
   in `MailTestCase::setUp()` immediately after `clearRecordCache()`.
+- The framework's `ApplicationTestCase::tearDown()` now clears Countries and Locales
+  caches after every transaction rollback, preventing stale singleton state from leaking
+  across tests at the framework level.
 - The research paper that concluded `Locales` was the only affected singleton was
   incorrect. `TenantCountriesCollection` and `NotificationLocalesManager` also hold
   country references, which is why `resetCollection()` cannot safely replace
@@ -76,6 +107,7 @@ knowledge.
 
 - `src/classes/DBHelper/BaseCollection.php` — `clearRecordCache()` and `resetCollection()` docblocks
 - `src/classes/Application/Locales/Locales.php` — `clearLocaleCache()`
-- `hcp-editor/tests/MailEditorTestClasses/MailTestCase.php` — current co-reset calls in `setUp()`
+- `tests/AppFrameworkTestClasses/ApplicationTestCase.php` — framework-level co-reset in `tearDown()`
+- `hcp-editor/tests/MailEditorTestClasses/MailTestCase.php` — HCP Editor co-reset calls in `setUp()`
 - `hcp-editor/docs/agents/projects/test-fixes.md` — full rationale for the current approach
 - `hcp-editor/docs/agents/plans/2026-07-16-countries-reset-collection/synthesis.md` — implementation notes

--- a/docs/agents/deferred-topics.md
+++ b/docs/agents/deferred-topics.md
@@ -1,0 +1,81 @@
+# Deferred Topics
+
+Topics where the current implementation is a known compromise and a cleaner solution
+should be pursued when the right approach has been identified. Each entry describes
+the limitation, the current workaround, and the conditions under which the deferred
+work should be revisited.
+
+---
+
+## DT-001 — Replace `clearRecordCache()` with a proper test-isolation event
+
+**Filed:** 2026-07-16  
+**Status:** Deferred — awaiting clean solution  
+**Area:** `DBHelper_BaseCollection`, `Application_Countries`, test infrastructure
+
+### Background
+
+`DBHelper_BaseCollection::clearRecordCache()` was introduced as a test-isolation helper
+for the countries singleton. The intended approach (using `resetCollection()`) disposes
+all cached record objects, which breaks any external code that legitimately holds
+references to those objects across `setUp()` boundaries — for example, tenant country
+collections (`TenantCountriesCollection`), notification locale managers
+(`NotificationLocalesManager`), and API method instances.
+
+`clearRecordCache()` works around this by only flushing the `getAll()` result cache
+(`$allRecords`) and the ISO-to-ID lookup (`$idLookup`) without disposing records. This
+is sufficient to prevent stale IDs from rolled-back test transactions from leaking into
+subsequent tests. However, it has two known gaps:
+
+1. **The per-ID record cache (`$records`) is not cleared.** A record created inside a
+   rolled-back transaction remains reachable via `getByID()` for the remainder of the
+   process lifetime. In practice this does not cause failures (no subsequent test has
+   the stale ID), but it is a correctness gap.
+
+2. **Co-resets must be managed manually.** Each singleton that lazily caches records
+   from the countries collection (currently `Locales` via `clearLocaleCache()`) must be
+   individually identified and co-reset in `setUp()`. This is fragile: adding a new
+   singleton that caches country records elsewhere in the codebase will silently
+   re-introduce the stale-reference problem unless the developer also adds a co-reset.
+
+### Desired Long-Term Solution
+
+The clean solution is an `onAfterClearCache` (or `onAfterResetCollection`) event on
+`BaseCollection` that interested parties can subscribe to. The countries collection would
+fire this event in both `clearRecordCache()` and `resetCollection()`. `Locales` and any
+other singleton that caches country records would subscribe and self-reset automatically.
+
+This would eliminate the manual co-reset calls in `MailTestCase::setUp()` and make the
+cache-invalidation contract part of the collection's API rather than test infrastructure
+knowledge.
+
+### What Must Happen Before This Can Be Resolved
+
+- Audit all singletons that hold references to `Application_Countries_Country` records.
+  The countries collection is not the only one affected; other collections may have the
+  same pattern.
+- Design the event API so that `resetCollection()` and `clearRecordCache()` can fire
+  distinct events (full dispose vs. cache-only flush), allowing subscribers to react
+  differently if needed.
+- Migrate all existing co-resets in `MailTestCase::setUp()` to event subscriptions.
+- Verify the full test suite passes (countries filter, mail suite, notifications suite)
+  after the migration.
+
+### Current State
+
+- `clearRecordCache()` is documented with its limitation in its docblock in
+  `src/classes/DBHelper/BaseCollection.php`.
+- `Locales::clearLocaleCache()` is the only registered co-reset; it is called explicitly
+  in `MailTestCase::setUp()` immediately after `clearRecordCache()`.
+- The research paper that concluded `Locales` was the only affected singleton was
+  incorrect. `TenantCountriesCollection` and `NotificationLocalesManager` also hold
+  country references, which is why `resetCollection()` cannot safely replace
+  `clearRecordCache()` today.
+
+### References
+
+- `src/classes/DBHelper/BaseCollection.php` — `clearRecordCache()` and `resetCollection()` docblocks
+- `src/classes/Application/Locales/Locales.php` — `clearLocaleCache()`
+- `hcp-editor/tests/MailEditorTestClasses/MailTestCase.php` — current co-reset calls in `setUp()`
+- `hcp-editor/docs/agents/projects/test-fixes.md` — full rationale for the current approach
+- `hcp-editor/docs/agents/plans/2026-07-16-countries-reset-collection/synthesis.md` — implementation notes

--- a/docs/agents/implementation-history/2026-07/2026-07-16-fix-test-suite-failures/plan.md
+++ b/docs/agents/implementation-history/2026-07/2026-07-16-fix-test-suite-failures/plan.md
@@ -1,0 +1,153 @@
+# Plan
+
+## Summary
+
+Fix all non-environment test failures in the framework test suite discovered during the PR readiness check for the `fix-stale-collection-objects` branch. The failures fall into three actionable categories: a test authoring bug using a normalized ISO country code, a stale Locales singleton caused by cross-test contamination from `resetCollection()` event listeners, and a test asserting against a class that unexpectedly declares the constant it was supposed to lack.
+
+## Architectural Context
+
+The framework test suite (1186 tests) runs against a seeded test database managed by `TestSuiteBootstrap`. Collections use the singleton pattern via `AppFactory` and register cross-collection event listeners (e.g. `Locales` listens to `Countries::onAfterDeleteRecord`). Test isolation relies on `ApplicationTestCase::setUp()`/`tearDown()` with transaction rollbacks, but singleton in-memory caches persist across tests.
+
+Key files:
+- `tests/AppFrameworkTests/DBHelper/DisposingTest.php` — tests collection disposing/reset behavior
+- `tests/AppFrameworkTests/Locales/CollectionTest.php` — tests Locales collection
+- `tests/AppFrameworkTests/Locales/LanguageTest.php` — tests language enumeration
+- `tests/AppFrameworkTests/UI/WizardPreselectionTest.php` — tests wizard step preselection
+- `tests/application/assets/classes/TestDriver/` — test driver classes
+- `src/classes/Application/Locales.php` — Locales singleton with `clearLocaleCache()`
+- `tests/ApplicationTestCase.php` — base test case with setUp/tearDown
+
+## Approach / Architecture
+
+Three independent fixes, each targeting a different failure category:
+
+1. **ISO code fix in DisposingTest** — Replace test country codes that conflict with seed data.
+2. **Locales singleton co-reset in tearDown** — Wire the existing `clearLocaleCache()` and `clearRecordCache()` APIs into `ApplicationTestCase::tearDown()` to prevent stale singleton state from leaking across tests.
+3. **WizardPreselectionTest fix** — Create a purpose-built test step class that omits the `STEP_NAME` constant, replacing the test's use of a class that unexpectedly declares it.
+
+## Rationale
+
+All three fixes are minimal, targeted corrections to test infrastructure. No production code changes are required. The Locales co-reset uses the `clearLocaleCache()` API already added on this branch rather than introducing new abstractions.
+
+## Considered Alternatives
+
+| Decision | Chosen Shape | Alternatives Considered | Trade-Off Summary |
+|----------|--------------|-------------------------|-------------------|
+| DisposingTest country codes | Replace `'uk'`/`'de'` with `'at'`/`'pl'` (non-seeded, non-normalized codes) | Use fictional codes like `'xx'`/`'yy'` | Real ISO codes are more realistic; fictional codes might trigger unexpected validation paths |
+| Locales tearDown co-reset | Add `clearRecordCache()` + `clearLocaleCache()` in `ApplicationTestCase::tearDown()` | Replace `resetCollection()` with `clearRecordCache()` in DisposingTest; Central `CacheResettable` interface | tearDown co-reset is the simplest fix; the generalized interface is deferred to DT-001 |
+| WizardPreselectionTest | New `NoStepName` test driver class without the constant | Remove constant from existing `Summary` class | Removing the constant from Summary could break other tests that depend on it |
+
+## Pattern Alignment
+
+- Follows the existing test driver pattern: new test fixture classes go under `tests/application/assets/classes/TestDriver/` — consistent with `Summary.php`, `Countries.php`, `Ticket.php` in the same directory.
+- Follows the existing tearDown cleanup pattern in `ApplicationTestCase` — adding cache resets alongside the existing transaction rollback.
+
+## Detailed Steps
+
+### Step 1: Fix DisposingTest ISO codes
+
+In `tests/AppFrameworkTests/DBHelper/DisposingTest.php`, method `test_resetCollection`:
+- Replace `'uk'` / `'United Kingdom'` with `'at'` / `'Austria'` (or another code not in `SEED_COUNTRIES` and not subject to normalization).
+- Replace `'de'` / `'Germany'` with `'pl'` / `'Poland'` (same criteria).
+
+### Step 2: Create NoStepName test driver class
+
+Create `tests/application/assets/classes/TestDriver/Area/WizardTest/Wizard/Step/NoStepName.php`:
+- Extend the wizard step base class.
+- Intentionally omit the `STEP_NAME` constant.
+- Implement required abstract methods (`render()`, `_process()`).
+
+Run `composer dump-autoload` after creating the file (classmap autoloading).
+
+### Step 3: Fix WizardPreselectionTest
+
+In `tests/AppFrameworkTests/UI/WizardPreselectionTest.php`, method `test_setStepValueByClass_throwsWithoutConstant`:
+- Replace the reference to `TestDriver_Area_WizardTest_Wizard_Step_Summary` with `TestDriver_Area_WizardTest_Wizard_Step_NoStepName`.
+
+### Step 4: Add Locales co-reset to tearDown
+
+In `ApplicationTestCase::tearDown()`, after the transaction rollback:
+- Add `AppFactory::createCountries()->clearRecordCache();`
+- Add `AppFactory::createLocales()->clearLocaleCache();`
+
+### Step 5: Verify fixes
+
+1. Run `DisposingTest` in isolation: `composer test-file -- tests/AppFrameworkTests/DBHelper/DisposingTest.php`
+2. Run `WizardPreselectionTest` in isolation: `composer test-file -- tests/AppFrameworkTests/UI/WizardPreselectionTest.php`
+3. Run `Locales\CollectionTest` and `Locales\LanguageTest` in isolation.
+4. Run the full suite excluding CAS: confirm all non-CAS tests pass.
+
+### Step 6: Update deferred topics
+
+In `docs/agents/deferred-topics.md`:
+- Add the generalized collection cache reset concept (central `CacheResettable` interface + `CollectionRegistry`) to DT-001.
+- Update the Current State section to reflect the new framework-level tearDown co-reset.
+
+### Step 7: Discard generated file noise
+
+Run `git restore docs/agents/project-manifest/modules-overview.md` to discard the timestamp-only diff from a prior `build-docs` run.
+
+## Dependencies
+
+- The `clearLocaleCache()` method on the `Locales` class must already exist (added earlier on the `fix-stale-collection-objects` branch).
+- The `clearRecordCache()` method on collection classes must already exist (added earlier on the same branch).
+
+## Required Components
+
+- `tests/AppFrameworkTests/DBHelper/DisposingTest.php` — edit
+- `tests/AppFrameworkTests/UI/WizardPreselectionTest.php` — edit
+- `tests/application/assets/classes/TestDriver/Area/WizardTest/Wizard/Step/NoStepName.php` — **new**
+- `tests/ApplicationTestCase.php` — edit
+- `docs/agents/deferred-topics.md` — edit
+
+## Assumptions
+
+- The `clearLocaleCache()` and `clearRecordCache()` APIs are already implemented and functional on this branch.
+- The test database is seeded (`composer seed-tests` has been run).
+- LDAP/CAS test failures are environment-specific and out of scope.
+
+## Constraints
+
+- No production code changes — all fixes are in test files and documentation.
+- Must use `array()` syntax (not `[]`) per project conventions.
+- New class files require `composer dump-autoload` for classmap autoloading.
+
+## Out of Scope
+
+- LDAP/CAS test failures (Category 4) — these require local environment configuration.
+- Generalized `CacheResettable` interface / `CollectionRegistry` — deferred to DT-001.
+- Refactoring `DisposingTest` to use `TestDBCollection` instead of live singletons.
+
+## Acceptance Criteria
+
+- `DisposingTest::test_resetCollection` passes without ISO duplicate key violations.
+- `WizardPreselectionTest::test_setStepValueByClass_throwsWithoutConstant` passes (exception is thrown as expected).
+- `Locales\CollectionTest::test_createCollection` passes in full-suite context (not just isolation).
+- `Locales\LanguageTest::test_collectionIsNotEmpty` passes in full-suite context.
+- `DeeplHelperTest` (all 4 tests) pass without separate changes (cascading fix from Step 1).
+- Full suite excluding CAS: all non-CAS tests pass (1188 tests, 3687 assertions).
+
+## Testing Strategy
+
+Run each fix in isolation first, then run the full suite (excluding CAS) to confirm no regressions and that the ordering-dependent failures are resolved.
+
+## Test Plan
+
+- `DisposingTest::test_resetCollection` — asserts country creation and collection reset work without duplicate key errors — covers AC 1
+- `WizardPreselectionTest::test_setStepValueByClass_throwsWithoutConstant` — asserts exception is thrown for a step class without `STEP_NAME` — covers AC 2
+- `Locales\CollectionTest::test_createCollection` — asserts `getAll()` returns non-empty after full-suite execution — covers AC 3
+- `Locales\LanguageTest::test_collectionIsNotEmpty` — asserts `getAll()` returns non-empty after full-suite execution — covers AC 4
+- `DeeplHelperTest` (4 tests) — asserts DeepL language mapping works — covers AC 5
+- Full suite excluding CAS — regression check — covers AC 6
+
+## Documentation Updates
+
+- `docs/agents/deferred-topics.md` — add DT-001 entry for generalized collection reset design, update Current State section.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| **New country codes (`'at'`, `'pl'`) might also conflict** | Verified against `SEED_COUNTRIES` — neither is in the seed list |
+| **tearDown co-reset is fragile** | Documented as known limitation in DT-001; generalized event-based solution planned |
+| **NoStepName class might need updating if wizard base class changes** | Minimal class with only required abstract methods; low maintenance burden |

--- a/docs/agents/implementation-history/2026-07/2026-07-16-fix-test-suite-failures/synthesis.md
+++ b/docs/agents/implementation-history/2026-07/2026-07-16-fix-test-suite-failures/synthesis.md
@@ -1,0 +1,34 @@
+## Synthesis
+
+### Completion Status
+- Date: 2026-07-16
+- Status: COMPLETE
+- Completed by: Standalone Developer Agent
+- Archived in Ledger: 2026-07-16
+
+### Outcome Summary
+
+Fixed all non-CAS test failures in the framework test suite: a test authoring bug using a normalized ISO code, a test asserting against a class that unexpectedly declared the constant it was supposed to lack, and a stale Locales singleton caused by cross-test contamination from `resetCollection()` event listeners.
+
+### Implementation Summary
+- **DisposingTest ISO code fix:** Replaced `'uk'`/`'de'` with `'at'`/`'pl'` in `test_resetCollection`. The original codes conflicted with seed data — `'uk'` normalizes to `'gb'` (already seeded) causing a duplicate key violation, and `'de'` is directly seeded.
+- **Locales singleton tearDown co-reset:** Added `clearRecordCache()` + `clearLocaleCache()` calls to `ApplicationTestCase::tearDown()` after the transaction rollback. This prevents the Countries `resetCollection()` event listener from leaving the Locales singleton in a stale/empty state for subsequent tests.
+- **WizardPreselectionTest fix:** The `test_setStepValueByClass_throwsWithoutConstant` test incorrectly used `TestDriver_Area_WizardTest_Wizard_Step_Summary`, which declares `STEP_NAME = 'Summary'`. Created a new `TestDriver_Area_WizardTest_Wizard_Step_NoStepName` class that intentionally omits the constant, and updated the test to use it.
+- **Deferred topics updated:** Added the generalized collection cache reset concept (central `CacheResettable` interface + `CollectionRegistry`) to DT-001 in `deferred-topics.md`, and updated the Current State section to reflect the new framework-level tearDown co-reset.
+
+### Documentation Updates
+- Updated `docs/agents/deferred-topics.md` — added generalized collection reset design notes and updated Current State/References sections.
+
+### Verification Summary
+- Tests run: `DisposingTest` (3 tests, 22 assertions, 2 incomplete), `WizardPreselectionTest` (9 tests, 18 assertions), `Locales\CollectionTest` (1 test), `Locales\LanguageTest` (1 test), `DeeplHelperTest` (4 tests), full suite excluding CAS (1188 tests, 3687 assertions)
+- Static analysis run: not re-run (no production code changed, only test files and documentation)
+- Result: All non-CAS tests pass. The 4 errors and 7 failures in the full run are exclusively LDAP/CAS integration tests requiring local config/server — pre-existing and out of scope.
+
+### Code Insights
+- [medium] (code-smell) `tests/AppFrameworkTests/DBHelper/DisposingTest.php`: ~~`test_resetCollection` tests the disposing behavior of `resetCollection()` by creating countries and then resetting the entire collection. This triggers event listeners registered by `Locales` (via `onAfterDeleteRecord`), causing side effects outside the test's scope. Consider whether this test should use the `TestDBCollection` fixture instead of the live `Application_Countries` singleton to avoid coupling to the event system.~~ **RESOLVED 2026-07-16:** Refactored `test_resetCollection` to use `TestDBCollection::getInstance()` and `createTestDBRecord()` instead of `AppFactory::createCountries()` and `createTestCountry()`. The `AppFactory` import was removed. All 3 tests pass (2 remain `markTestIncomplete`).
+- [low] (debt) `tests/application/assets/classes/TestDriver/Area/WizardTest/Wizard/Step/Summary.php`: ~~The `render()` and `_process()` methods lack visibility keywords consistent with the other step classes (`Countries`, `Ticket`). `render()` uses default visibility, `_process()` is `public` — both should match the parent's contract explicitly.~~ **RESOLVED 2026-07-16:** Added `public` to `render()`. `_process()` already had `public`; no change needed.
+- [low] (convention) `ApplicationTestCase::tearDown()`: ~~The co-reset calls are effective but fragile — adding a new singleton that caches country records requires remembering to add another co-reset line here. This is documented in DT-001 as a known limitation pending the event-based solution.~~ **ACKNOWLEDGED**
+
+### Additional Comments
+- The `composer dump-autoload` step was required after adding the new `NoStepName` step class (classmap autoloading).
+- The DeeplHelper tests (Category 3 in the investigation) were cascading failures caused by the DisposingTest ISO bug. With that fix in place, they pass without any separate changes.

--- a/src/classes/Application/Locales/Locales.php
+++ b/src/classes/Application/Locales/Locales.php
@@ -48,6 +48,18 @@ class Locales extends BaseStringPrimaryCollection
         $countries->onAfterDeleteRecord($this->reset(...));
     }
 
+    /**
+     * Clears the locale cache, forcing all locale objects to be
+     * recreated on the next access. Use this after resetting the
+     * countries collection to prevent stale country references.
+     *
+     * @return void
+     */
+    public function clearLocaleCache() : void
+    {
+        $this->reset();
+    }
+
     public static function getAPIMethodsFolder() : FolderInfo
     {
         return FolderInfo::factory(__DIR__.'/API/Methods');

--- a/src/classes/DBHelper/BaseCollection.php
+++ b/src/classes/DBHelper/BaseCollection.php
@@ -275,6 +275,24 @@ abstract class DBHelper_BaseCollection implements DBHelperCollectionInterface
         }
     }
 
+    /**
+     * Fully resets the collection by disposing every cached record object and
+     * clearing all in-memory caches. Use this when you need a completely clean
+     * slate — i.e., when no external code holds references to the records and
+     * you want to guarantee that all subsequent accesses re-fetch from the DB.
+     *
+     * **Caution — do not use in test setUp routines** when the collection is a
+     * singleton whose records are legitimately held by other singletons (e.g.
+     * tenant country collections, notification locale managers). Disposing the
+     * records in that case will cause `DisposableDisposedException` errors in
+     * any code that still holds a reference to the old objects.
+     *
+     * Use {@see self::clearRecordCache()} instead when you only need to prevent
+     * stale IDs from appearing in `getAll()` results (the typical test-isolation
+     * use case) without breaking existing object references.
+     *
+     * @return $this
+     */
     public function resetCollection() : self
     {
         $this->log(sprintf('Resetting the collection. [%s] records were loaded.', count($this->records)));
@@ -297,6 +315,42 @@ abstract class DBHelper_BaseCollection implements DBHelperCollectionInterface
 
         $this->allRecords = null;
         $this->idLookup = array();
+    }
+
+    /**
+     * Clears only the in-memory `getAll()` result cache and the ISO-to-ID
+     * lookup, without touching the per-ID record cache (`$records`) and
+     * without disposing any record objects. Existing references held by
+     * callers remain fully valid after this call.
+     *
+     * **When to use this instead of {@see self::resetCollection()}:**
+     *
+     * Prefer `clearRecordCache()` in test `setUp()` routines where the
+     * collection is a long-lived singleton whose records are legitimately
+     * held by other singletons (e.g. a countries collection whose records are
+     * cached inside tenant country collections, notification locale managers,
+     * or API method instances). `resetCollection()` would dispose those records
+     * and trigger `DisposableDisposedException` in any code that still holds a
+     * reference, while `clearRecordCache()` only flushes the `getAll()` result
+     * cache — which is sufficient to prevent stale IDs from rolled-back test
+     * transactions from leaking into subsequent tests.
+     *
+     * **Limitation:** The per-ID record cache (`$records`) is NOT cleared.
+     * If a test creates a record inside a transaction, that record is loaded
+     * into `$records` during the test, and the transaction is later rolled
+     * back, the stale object will remain reachable via `getByID()`. In
+     * practice this is not a problem because no subsequent test knows the
+     * stale ID — but it is a theoretical correctness gap. See the deferred
+     * item in `docs/agents/deferred-topics.md` for the long-term plan.
+     *
+     * **Must be paired with co-resets** for any singletons whose objects
+     * lazily cache records from this collection. For the countries collection,
+     * call `Locales::getInstance()->clearLocaleCache()` immediately after to
+     * prevent stale country references from surviving in `Locale` objects.
+     */
+    public function clearRecordCache() : void
+    {
+        $this->invalidateMemoryCache();
     }
 
     public function getByRequest() : ?DBHelperRecordInterface

--- a/tests/AppFrameworkTestClasses/ApplicationTestCase.php
+++ b/tests/AppFrameworkTestClasses/ApplicationTestCase.php
@@ -74,6 +74,14 @@ abstract class ApplicationTestCase extends TestCase implements ApplicationTestCa
         // is NOT reset by transaction rollback.
         DBHelper::update("SET FOREIGN_KEY_CHECKS=1", array());
 
+        // Flush in-memory collection caches after rolling back the transaction.
+        // Transaction rollback restores the DB state but not the singleton caches,
+        // which can leak stale IDs or disposed records into subsequent tests.
+        // Countries must be cleared first; Locales depends on it.
+        // @see DT-001 in docs/agents/deferred-topics.md for the long-term plan.
+        AppFactory::createCountries()->clearRecordCache();
+        AppFactory::createLocales()->clearLocaleCache();
+
         if($this instanceof ImageMediaTestInterface) {
             $this->tearDownImageTestCase();
         }

--- a/tests/AppFrameworkTests/Application/Admin/Wizard/WizardPreselectionTest.php
+++ b/tests/AppFrameworkTests/Application/Admin/Wizard/WizardPreselectionTest.php
@@ -8,7 +8,7 @@ use Application\Admin\Wizard\WizardPreselection;
 use Application_Exception;
 use PHPUnit\Framework\TestCase;
 use TestDriver_Area_WizardTest_Wizard_Step_Countries;
-use TestDriver_Area_WizardTest_Wizard_Step_Summary;
+use TestDriver_Area_WizardTest_Wizard_Step_NoStepName;
 
 final class WizardPreselectionTest extends TestCase
 {
@@ -110,7 +110,7 @@ final class WizardPreselectionTest extends TestCase
         $this->expectExceptionCode(WizardPreselection::ERROR_STEP_CLASS_MISSING_STEP_NAME);
 
         $preselection->setStepValueByClass(
-            TestDriver_Area_WizardTest_Wizard_Step_Summary::class,
+            TestDriver_Area_WizardTest_Wizard_Step_NoStepName::class,
             'key',
             'value'
         );

--- a/tests/AppFrameworkTests/DBHelper/DisposingTest.php
+++ b/tests/AppFrameworkTests/DBHelper/DisposingTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AppFrameworkTests\DBHelper;
 
-use Application\AppFactory;
 use Mistralys\AppFrameworkTests\TestClasses\DBHelperTestCase;
 use TestDriver\TestDBRecords\TestDBCollection;
 
@@ -12,10 +11,10 @@ final class DisposingTest extends DBHelperTestCase
 {
     public function test_resetCollection(): void
     {
-        $collection = AppFactory::createCountries();
+        $collection = TestDBCollection::getInstance();
 
-        $this->createTestCountry('uk', 'United Kingdom');
-        $this->createTestCountry('de', 'Germany');
+        $this->createTestDBRecord();
+        $this->createTestDBRecord();
 
         $records = $collection->getAll();
 

--- a/tests/application/assets/classes/TestDriver/Area/WizardTest/Wizard/Step/NoStepName.php
+++ b/tests/application/assets/classes/TestDriver/Area/WizardTest/Wizard/Step/NoStepName.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * A minimal concrete step class that intentionally does NOT declare a
+ * STEP_NAME constant. Used by {@see WizardPreselectionTest} to verify
+ * that {@see \Application\Admin\Wizard\WizardPreselection::setStepValueByClass()}
+ * throws when the constant is missing.
+ */
+class TestDriver_Area_WizardTest_Wizard_Step_NoStepName extends TestDriver_Area_WizardTest_Wizard_Step
+{
+    public function render() : string
+    {
+        return '';
+    }
+
+    public function initDone() : void
+    {
+    }
+
+    protected function preProcess() : void
+    {
+    }
+
+    public function getLabel() : string
+    {
+        return 'NoStepName';
+    }
+
+    protected function getDefaultData() : array
+    {
+        return array();
+    }
+
+    public function _process() : bool
+    {
+        return true;
+    }
+
+    public function getAbstract() : string
+    {
+        return '';
+    }
+}

--- a/tests/application/assets/classes/TestDriver/Area/WizardTest/Wizard/Step/Summary.php
+++ b/tests/application/assets/classes/TestDriver/Area/WizardTest/Wizard/Step/Summary.php
@@ -7,7 +7,7 @@ class TestDriver_Area_WizardTest_Wizard_Step_Summary extends TestDriver_Area_Wiz
     public const string STEP_NAME = 'Summary';
 
 
-    function render() : string
+    public function render() : string
     {
         return $this->renderFormable();
     }


### PR DESCRIPTION
This pull request introduces targeted improvements to the test infrastructure to address test suite failures caused by stale cached data in singleton collections, and documents both the current workaround and long-term plans for a more robust solution. The main changes include new cache reset APIs, improved documentation, and updates to the test suite setup/teardown process to ensure test isolation.